### PR TITLE
feature documentation

### DIFF
--- a/src/core/api-objects/iMockApi.ts
+++ b/src/core/api-objects/iMockApi.ts
@@ -1,3 +1,23 @@
+export interface UpdatePolicy {
+    /**
+     * When true, the mock will be updated with the real API response
+     * if the response status is in the allowedStatusCodes array
+     */
+    enabled: boolean;
+
+    /**
+     * Array of status codes that are allowed to update the mock
+     * Default is [200]
+     */
+    allowedStatusCodes?: number[];
+
+    /**
+     * When true, will update mock even if response body differs from current mock
+     * Default is false
+     */
+    forceUpdate?: boolean;
+}
+
 export interface MockApi {
     /**
      * Mock a GET request to the specified URL
@@ -39,4 +59,30 @@ export interface MockApi {
      * Save recorded responses to mock files
      */
     saveRecordedResponses(): Promise<void>;
+
+    /**
+     * Enable/disable update mode for API calls
+     * When enabled, actual API responses will update existing mock files
+     */
+    setUpdateMode(enabled: boolean): void;
+
+    /**
+     * Get current update mode status
+     */
+    isUpdateMode(): boolean;
+
+    /**
+     * Set update policy for a specific mock
+     */
+    setUpdatePolicy(url: string | RegExp, policy: UpdatePolicy): void;
+
+    /**
+     * Get update policy for a specific mock
+     */
+    getUpdatePolicy(url: string | RegExp): UpdatePolicy | undefined;
+
+    /**
+     * Clear all update policies
+     */
+    clearUpdatePolicies(): void;
 } 

--- a/src/core/readme.md
+++ b/src/core/readme.md
@@ -1,0 +1,45 @@
+# Mock API Implementation Documentation
+
+## Overview
+
+The `MockApiImpl` class provides a robust implementation of the `MockApi` interface for mocking HTTP requests during testing. This feature enables reliable, repeatable tests by allowing you to:
+
+- Record real API responses and save them as mock data
+- Replay recorded responses in subsequent test runs
+- Selectively update existing mocks with new responses
+- Configure fine-grained update policies per endpoint
+
+## Key Features
+
+### 1. Mock Mode (Default)
+
+- Intercepts HTTP requests and returns predefined mock responses
+- Supports all common HTTP methods (GET, POST, PUT, DELETE)
+- Configurable response status codes and headers
+- Default content-type is application/json
+- Automatic response body serialization/deserialization
+
+### 2. Record Mode
+
+- Captures real API responses during test execution
+- Automatically saves responses as JSON files
+- Maintains complete response structure:
+  - Status code
+  - Headers
+  - Response body
+- Files are named based on HTTP method and sanitized URL
+- Stored in configurable mock data directory
+
+### 3. Update Mode
+
+- Allows updating existing mock files with new responses
+- Configurable update policies per URL pattern
+- Supports conditional updates based on:
+  - Response status codes
+  - Response body comparison
+- Preserves existing mocks when updates fail
+- Logging of all update operations
+
+## Usage
+
+### Basic Mocking

--- a/store/mock-data/README.md
+++ b/store/mock-data/README.md
@@ -1,0 +1,41 @@
+# Mock API Feature Documentation
+
+## Overview
+
+The Mock API feature provides a robust mechanism for mocking HTTP requests during testing. It supports recording real API responses, saving them as mock data, and replaying them in subsequent test runs. This feature is particularly useful for:
+
+- Creating reliable, repeatable tests that don't depend on external services
+- Testing error scenarios and edge cases
+- Reducing test execution time
+- Working offline
+- Avoiding rate limits from external APIs
+
+## Key Features
+
+### 1. Recording Mode
+
+- Captures real API responses and saves them as mock data
+- Automatically creates JSON files for each unique request
+- Maintains the original response structure including status, headers, and body
+
+### 2. Mock Mode
+
+- Intercepts HTTP requests and returns saved mock responses
+- Supports GET, POST, PUT, and DELETE methods
+- Maintains request/response integrity with proper status codes and headers
+
+### 3. Update Mode
+
+- Allows selective updating of existing mock data
+- Supports update policies for fine-grained control
+- Can force updates or use conditional updating based on response comparison
+
+### 4. Update Policies
+
+- Configure per-URL update behaviors
+- Control allowed status codes
+- Enable forced updates or conditional updates
+
+## Usage
+
+### Basic Mock Setup


### PR DESCRIPTION
### TL;DR
Added update mode functionality to the Mock API implementation, allowing selective updates of existing mock responses with new API data.

### What changed?
- Introduced new update mode feature with granular control through UpdatePolicy interface
- Added ability to selectively update existing mock files based on status codes and response comparison
- Implemented policy-based update controls per URL pattern
- Added comprehensive documentation for mock API features and usage
- Created new methods: setUpdateMode, isUpdateMode, setUpdatePolicy, getUpdatePolicy, and clearUpdatePolicies

### How to test?
1. Enable update mode using `setUpdateMode(true)`
2. Configure update policies for specific endpoints:
```typescript
mockApi.setUpdatePolicy('/api/endpoint', {
    enabled: true,
    allowedStatusCodes: [200],
    forceUpdate: false
});
```
3. Run tests and verify that mock files are updated according to policies
4. Check mock data directory for updated response files

### Why make this change?
This enhancement provides more control over mock data management, allowing teams to:
- Selectively update mock responses without recording all endpoints
- Maintain test reliability by controlling which responses can be updated
- Ensure mock data stays current with production APIs while preventing unwanted updates
- Reduce maintenance overhead by automating mock updates in a controlled manner